### PR TITLE
idmarjr/add-editorconfig-file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = false
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Use .editorconfig file to help to keep code style uniform
Define patterns already used in the project

- Use UTF-8 charset
- lf as line ending
- Indent using spaces
- Indent size: 4
- Remove extra spaces in the end of line
- Do not insert a empty line in the end of file

For markdown files:
- Do not remove extra spaces in the end of line since markdown uses two spaces in the end of line to break content in a new line when rendering the file.

To know more about EditorConfig:
https://editorconfig.org/